### PR TITLE
Add Create and GetLatestVersion methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ func main() {
 	for key, value := range secrets {
 		fmt.Printf("%s: %s\n", key, value)
 	}
+
+	secretVersion, err := client.GetLatestVersion("MY_APP_SECRET")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	
+	newSecretVersion, err := client.Create("MY_APP_SECRET")
+	if err != nil {
+		log.Fatalln(err)
+	}
 }
 ```
 
@@ -61,5 +71,7 @@ func main() {
   - **Client.Get(name)**: Fetches secret value from the specified application.
   - **Client.List()**: List all secrets in the specified application.
   - **Client.GetAll()**: Get value of all secrets in the specified application.
+  - **Client.GetLatestVersion()**: Get latest version number of secret from the specified application.
+  - **Client.Create()**: Create new secret in the specified application. 
 
 Copyright 2023 Saeid Bostandoust <ssbostan@yahoo.com>

--- a/client_test.go
+++ b/client_test.go
@@ -41,6 +41,31 @@ func TestGet(t *testing.T) {
 	}
 }
 
+func TestGetLatestVersion(t *testing.T) {
+	tests := []struct {
+		secretName    string
+		expectedValue int
+	}{
+		{"NOT_FOUND_SECRET", 0},
+		{"SDK_TEST", 1},
+	}
+
+	for _, test := range tests {
+		version, _ := client.GetLatestVersion(test.secretName)
+		if version != test.expectedValue {
+			t.Errorf("client GetLatestVersion error: Could not meet expected value.")
+		}
+	}
+}
+
+func TestCreate(t *testing.T) {
+	version, _ := client.GetLatestVersion("MY_APP_SECRET")
+	newVersion, _ := client.Create("MY_APP_SECRET", "SDK_TEST")
+	if version+1 != newVersion {
+		t.Errorf("client Create error: New version of secret was not created")
+	}
+}
+
 func TestList(t *testing.T) {
 	secrets, err := client.List()
 	if err != nil {


### PR DESCRIPTION
This is a PR to an additional method for the client to create a new secret in an application `Create`. 

I've included a method for checking the latest version `GetLatestVersion` of a secret since this number will be increasing if a secret with the same name is added to an application more than once, it'll update the secret in place. 